### PR TITLE
Fix NPE when running pr-check in midstream

### DIFF
--- a/integration-tests/src/main/java/org/bf2/srs/fleetmanager/it/TestInfraManager.java
+++ b/integration-tests/src/main/java/org/bf2/srs/fleetmanager/it/TestInfraManager.java
@@ -140,6 +140,8 @@ public class TestInfraManager {
             tenantManagerAuthConfig = new AuthConfig();
             tenantManagerAuthConfig.keycloakUrl = getMandatoryEnvVar(MAS_SSO_URL);
             tenantManagerAuthConfig.realm = getMandatoryEnvVar(MAS_SSO_REALM);
+            tenantManagerAuthConfig.tokenEndpoint = tenantManagerAuthConfig.keycloakUrl + "/realms/"
+                    + tenantManagerAuthConfig.realm + "/protocol/openid-connect/token";
             tenantManagerAuthConfig.clientId = getMandatoryEnvVar(MAS_SSO_CLIENT_ID);
             tenantManagerAuthConfig.clientSecret = getMandatoryEnvVar(MAS_SSO_CLIENT_SECRET);
 


### PR DESCRIPTION
The NPE occured here https://github.com/bf2fc6cc711aee1a0c2a/srs-fleet-manager/blob/6c032f22fa6bddeee8dc29ed515526046fc1c645/integration-tests/src/test/java/org/bf2/srs/fleetmanager/it/Utils.java#L68 by `tmAuth.tokenEndpoint` being `null`.