### PR TITLE
fix: add custom auth error handler

### DIFF
--- a/account-management-service/src/main/java/org/bf2/srs/fleetmanager/spi/impl/AccountManagementServiceProducer.java
+++ b/account-management-service/src/main/java/org/bf2/srs/fleetmanager/spi/impl/AccountManagementServiceProducer.java
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import java.util.Collections;
+import java.util.Optional;
 
 @ApplicationScoped
 public class AccountManagementServiceProducer {
@@ -38,7 +39,7 @@ public class AccountManagementServiceProducer {
         logger.info("Using Account Management Service with Account Management URL: {}", endpoint);
         AccountManagementSystemRestClient restClient;
         if (ssoEnabled) {
-            final OidcAuth auth = new OidcAuth(ssoTokenEndpoint, ssoClientId, ssoClientSecret);
+            final OidcAuth auth = new OidcAuth(ssoTokenEndpoint, ssoClientId, ssoClientSecret, Optional.of(new AccountManagementSystemErrorHandler()));
             restClient = new AccountManagementSystemRestClient(endpoint, Collections.emptyMap(), auth);
         } else {
             restClient = new AccountManagementSystemRestClient(endpoint, Collections.emptyMap(), null);

--- a/account-management-service/src/main/java/org/bf2/srs/fleetmanager/spi/impl/AccountManagementSystemErrorHandler.java
+++ b/account-management-service/src/main/java/org/bf2/srs/fleetmanager/spi/impl/AccountManagementSystemErrorHandler.java
@@ -1,0 +1,25 @@
+package org.bf2.srs.fleetmanager.spi.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.apicurio.rest.client.auth.exception.AuthErrorHandler;
+import io.apicurio.rest.client.error.ApicurioRestClientException;
+import org.bf2.srs.fleetmanager.spi.impl.exception.AccountManagementSystemClientException;
+
+import java.io.InputStream;
+
+public class AccountManagementSystemErrorHandler extends AuthErrorHandler {
+    @Override
+    public ApicurioRestClientException handleErrorResponse(InputStream inputStream, int i) {
+        return super.handleErrorResponse(inputStream, i);
+    }
+
+    @Override
+    public ApicurioRestClientException parseError(Exception e) {
+        return new AccountManagementSystemClientException(e);
+    }
+
+    @Override
+    public ApicurioRestClientException parseInputSerializingError(JsonProcessingException e) {
+        return new AccountManagementSystemClientException(e);
+    }
+}

--- a/integration-tests/src/test/java/org/bf2/srs/fleetmanager/it/Utils.java
+++ b/integration-tests/src/test/java/org/bf2/srs/fleetmanager/it/Utils.java
@@ -16,6 +16,7 @@ import org.bf2.srs.fleetmanager.spi.model.AccountInfo;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -62,7 +63,7 @@ public class Utils {
         var infra = TestInfraManager.getInstance();
         if (infra.isTenantManagerAuthEnabled()) {
             var tmAuth = infra.getTenantManagerAuthConfig();
-            OidcAuth auth = new OidcAuth(tmAuth.tokenEndpoint, tmAuth.clientId, tmAuth.clientSecret);
+            OidcAuth auth = new OidcAuth(tmAuth.tokenEndpoint, tmAuth.clientId, tmAuth.clientSecret, Optional.empty());
             // TODO uncomment
             // {
             //     //verify tenant manager auth

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <!-- Other -->
         <lombok.version>1.18.16</lombok.version>
         <apicurio-registry-tenant-manager-client.version>2.1.0-SNAPSHOT</apicurio-registry-tenant-manager-client.version>
-        <apicurio-common-rest-client.version>0.0.5.Final</apicurio-common-rest-client.version>
+        <apicurio-common-rest-client.version>0.0.7.Final</apicurio-common-rest-client.version>
         <keycloak.version>11.0.3</keycloak.version>
         <keycloak.testcontainers.version>1.5.0</keycloak.testcontainers.version>
         <embedded-postgres.version>1.2.10</embedded-postgres.version>

--- a/tenant-manager-client/src/main/java/org/bf2/srs/fleetmanager/spi/impl/TenantManagerClientProducer.java
+++ b/tenant-manager-client/src/main/java/org/bf2/srs/fleetmanager/spi/impl/TenantManagerClientProducer.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import java.util.Optional;
 
 @ApplicationScoped
 public class TenantManagerClientProducer {
@@ -33,7 +34,7 @@ public class TenantManagerClientProducer {
     public TenantManagerService produce() {
         if (tenantManagerAuthEnabled) {
             log.info("Using Apicurio Registry REST TenantManagerClient with authentication enabled.");
-            return new RestClientTenantManagerServiceImpl(new OidcAuth(tenantManagerAuthServerUrl, tenantManagerAuthClientId, tenantManagerAuthSecret));
+            return new RestClientTenantManagerServiceImpl(new OidcAuth(tenantManagerAuthServerUrl, tenantManagerAuthClientId, tenantManagerAuthSecret, Optional.empty()));
         } else {
             log.info("Using Apicurio Registry REST TenantManagerClient.");
             return new RestClientTenantManagerServiceImpl();


### PR DESCRIPTION
There's a stacktrace in staging showing that the wrong method is being called, resulting in the application throwing a `UnsupportedOperationException`. That method should not be used thus the exception shouldn't be thrown. There's probably an underlying bug that is causing the wrong method to be called in the error handler. This will bring some light by throwing the real exception instead of the wrong one.