### PR TITLE
Create eval instances without reserving quota in AMS

### DIFF
--- a/account-management-service/src/main/java/org/bf2/srs/fleetmanager/spi/impl/AccountManagementServiceImpl.java
+++ b/account-management-service/src/main/java/org/bf2/srs/fleetmanager/spi/impl/AccountManagementServiceImpl.java
@@ -90,6 +90,12 @@ public class AccountManagementServiceImpl implements AccountManagementService {
             throw new TermsRequiredException(accountInfo.getAccountUsername());
         }
 
+        // If we're creating an eval instance, don't bother invoking AMS - return a null subscriptionId
+        // TODO remove this once we have RHOSRTrial working.
+        if (resourceType == ResourceType.REGISTRY_INSTANCE_EVAL) {
+            return null;
+        }
+
         // Set the productId and resourceName based on if it's an Eval or Standard instance
         String productId = amsProperties.standardProductId;
         String resourceName = amsProperties.standardResourceName;
@@ -134,6 +140,10 @@ public class AccountManagementServiceImpl implements AccountManagementService {
 
     @Override
     public void deleteSubscription(String subscriptionId) {
-        restClient.deleteSubscription(subscriptionId);
+        // If the subscriptionId is null, it means we didn't reserve quota in AMS for this
+        // instances (likely because it's an Eval instance).
+        if (subscriptionId != null) {
+            restClient.deleteSubscription(subscriptionId);
+        }
     }
 }

--- a/core/src/main/java/org/bf2/srs/fleetmanager/storage/sqlPanacheImpl/model/RegistryData.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/storage/sqlPanacheImpl/model/RegistryData.java
@@ -1,14 +1,9 @@
 package org.bf2.srs.fleetmanager.storage.sqlPanacheImpl.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import static lombok.AccessLevel.PACKAGE;
 
 import java.time.Instant;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -16,7 +11,13 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import static lombok.AccessLevel.PACKAGE;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 /**
  * @author Jakub Senko <jsenko@redhat.com>


### PR DESCRIPTION
@jsenko and @carlesarnal feel free to merge this if you think it will help.  I checked the DB schema and NULLs are allowed for the subscriptionId.