### PR TITLE
Update quarkus version to 2.2.3.Final

### DIFF
--- a/account-management-service/pom.xml
+++ b/account-management-service/pom.xml
@@ -34,7 +34,7 @@
 
         <dependency>
             <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-common-rest-client-auth</artifactId>
+            <artifactId>apicurio-common-rest-client-jdk</artifactId>
         </dependency>
 
         <!-- Other -->

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -132,6 +132,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.apicurio</groupId>
             <artifactId>apicurio-registry-tenant-manager-client</artifactId>
             <version>${apicurio-registry-tenant-manager-client.version}</version>

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -59,6 +59,7 @@ srs-fleet-manager.version=${project.version}
 %test.quarkus.log.console.enable=true
 
 %test.quarkus.flyway.locations=db/migration/h2
+%test.quarkus.quartz.start-mode=halted
 
 # === Auth - disabled by default
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,14 @@
         <!-- Quarkus -->
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
-        <quarkus.platform.version>1.13.2.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.2.3.Final</quarkus.platform.version>
 
         <quarkus-plugin.version>${quarkus.platform.version}</quarkus-plugin.version>
 
         <!-- Other -->
         <lombok.version>1.18.16</lombok.version>
         <apicurio-registry-tenant-manager-client.version>2.1.0.Final</apicurio-registry-tenant-manager-client.version>
-        <apicurio-common-rest-client.version>0.0.7.Final</apicurio-common-rest-client.version>
+        <apicurio-common-rest-client.version>0.0.9.Final</apicurio-common-rest-client.version>
         <keycloak.version>11.0.3</keycloak.version>
         <keycloak.testcontainers.version>1.5.0</keycloak.testcontainers.version>
         <embedded-postgres.version>1.2.10</embedded-postgres.version>
@@ -132,7 +132,7 @@
 
             <dependency>
                 <groupId>io.apicurio</groupId>
-                <artifactId>apicurio-common-rest-client-auth</artifactId>
+                <artifactId>apicurio-common-rest-client-jdk</artifactId>
                 <version>${apicurio-common-rest-client.version}</version>
             </dependency>
 


### PR DESCRIPTION
@jsenko note that this is going to fail until [this](https://github.com/Apicurio/apicurio-registry/pull/1526) is merged *and* released as a new version since the tenant-manager-client there is required here.