### PR TITLE
Support for multiple T&C event codes

### DIFF
--- a/account-management-service/src/main/java/org/bf2/srs/fleetmanager/spi/impl/AccountManagementServiceProperties.java
+++ b/account-management-service/src/main/java/org/bf2/srs/fleetmanager/spi/impl/AccountManagementServiceProperties.java
@@ -16,9 +16,11 @@
 
 package org.bf2.srs.fleetmanager.spi.impl;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import java.util.List;
 
 import javax.inject.Singleton;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 /**
  * @author eric.wittmann@gmail.com
@@ -29,7 +31,7 @@ public class AccountManagementServiceProperties {
     @ConfigProperty(name = "srs-fleet-manager.ams.terms.mas-site-code", defaultValue = "ocm")
     String termsSiteCode;
     @ConfigProperty(name = "srs-fleet-manager.ams.terms.mas-event-code", defaultValue = "onlineService")
-    String termsEventCode;
+    List<String> termsEventCode;
 
     @ConfigProperty(name = "srs-fleet-manager.ams.resources.resource-type")
     String resourceType;

--- a/core/src/main/java/org/bf2/srs/fleetmanager/operation/auditing/impl/AuditingAuthenticationMechanism.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/operation/auditing/impl/AuditingAuthenticationMechanism.java
@@ -16,6 +16,25 @@
 
 package org.bf2.srs.fleetmanager.operation.auditing.impl;
 
+import static org.bf2.srs.fleetmanager.AuditingServletFilter.HEADER_X_FORWARDED_FOR;
+import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.KEY_ERROR_MESSAGE;
+import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.KEY_REQUEST_FORWARDED_FOR;
+import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.KEY_REQUEST_METHOD;
+import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.KEY_REQUEST_PATH;
+import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.KEY_REQUEST_SOURCE_IP;
+import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.KEY_RESPONSE_CODE;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import javax.annotation.Priority;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+
+import org.bf2.srs.fleetmanager.operation.auditing.AuditingEvent;
+
 import io.quarkus.arc.profile.UnlessBuildProfile;
 import io.quarkus.oidc.runtime.BearerAuthenticationMechanism;
 import io.quarkus.oidc.runtime.OidcAuthenticationMechanism;
@@ -29,20 +48,6 @@ import io.quarkus.vertx.http.runtime.security.HttpCredentialTransport;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.web.RoutingContext;
-import org.bf2.srs.fleetmanager.operation.auditing.AuditingEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Collections;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import javax.annotation.Priority;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
-import javax.inject.Inject;
-
-import static org.bf2.srs.fleetmanager.AuditingServletFilter.HEADER_X_FORWARDED_FOR;
-import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.*;
 
 /**
  * Custom HttpAuthenticationMechanism that simply wraps OidcAuthenticationMechanism.
@@ -57,7 +62,7 @@ import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstan
 @ApplicationScoped
 public class AuditingAuthenticationMechanism implements HttpAuthenticationMechanism {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+//    private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Inject
     OidcAuthenticationMechanism oidcAuthenticationMechanism;

--- a/core/src/main/java/org/bf2/srs/fleetmanager/storage/ResourceStorage.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/storage/ResourceStorage.java
@@ -4,15 +4,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.transaction.Transactional;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-import io.quarkus.hibernate.orm.panache.PanacheQuery;
-import io.quarkus.panache.common.Sort;
 import org.bf2.srs.fleetmanager.storage.sqlPanacheImpl.model.RegistryData;
 import org.bf2.srs.fleetmanager.storage.sqlPanacheImpl.model.RegistryDeploymentData;
 import org.bf2.srs.fleetmanager.util.SearchQuery;
+
+import io.quarkus.hibernate.orm.panache.PanacheQuery;
+import io.quarkus.panache.common.Sort;
 
 /**
  * @author Jakub Senko <jsenko@redhat.com>

--- a/core/src/test/java/org/bf2/srs/fleetmanager/execution/manager/TaskManagerTest.java
+++ b/core/src/test/java/org/bf2/srs/fleetmanager/execution/manager/TaskManagerTest.java
@@ -1,6 +1,19 @@
 package org.bf2.srs.fleetmanager.execution.manager;
 
-import io.quarkus.test.junit.QuarkusTest;
+import static java.lang.Long.valueOf;
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofSeconds;
+import static java.time.Instant.now;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import javax.inject.Inject;
+
 import org.bf2.srs.fleetmanager.execution.impl.tasks.TestTask;
 import org.bf2.srs.fleetmanager.execution.impl.tasks.TestTask.BasicCommand;
 import org.bf2.srs.fleetmanager.execution.impl.tasks.TestTask.RetryCommand;
@@ -10,19 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
-import java.time.Instant;
-import javax.enterprise.context.control.ActivateRequestContext;
-import javax.inject.Inject;
-
-import static java.lang.Long.valueOf;
-import static java.time.Duration.ofMillis;
-import static java.time.Duration.ofSeconds;
-import static java.time.Instant.now;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.jupiter.api.Assertions.fail;
+import io.quarkus.test.junit.QuarkusTest;
 
 /**
  * @author Jakub Senko <jsenko@redhat.com>


### PR DESCRIPTION
This allows us to transition more smoothly from one set of T&C to another.  If multiple event codes are specified in the configuration (by providing a comma separate list of codes), then the user will only need to have agreed to **ONE** of them.
