### PR TITLE
Fix usage metrics

### DIFF
--- a/core/src/main/java/org/bf2/srs/fleetmanager/operation/metrics/UsageMetrics.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/operation/metrics/UsageMetrics.java
@@ -1,7 +1,10 @@
 package org.bf2.srs.fleetmanager.operation.metrics;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
+import io.quarkus.arc.Arc;
+
 import org.bf2.srs.fleetmanager.rest.service.RegistryService;
 import org.bf2.srs.fleetmanager.rest.service.model.RegistryInstanceTypeValueDto;
 import org.bf2.srs.fleetmanager.rest.service.model.RegistryStatusValueDto;
@@ -22,8 +25,6 @@ import static org.bf2.srs.fleetmanager.operation.metrics.Constants.*;
 public class UsageMetrics {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
-
-    private static final Object DUMMY = new Object(); // Prevents NaN values on gauges, caused by garbage collection
 
     @Inject
     MeterRegistry metrics;
@@ -53,19 +54,57 @@ public class UsageMetrics {
         nextExpiration = Instant.now().plus(Duration.ofSeconds(stagger));
 
         for (RegistryStatusValueDto status : RegistryStatusValueDto.values()) {
-            metrics.gauge(USAGE_STATISTICS_REGISTRIES_STATUS, Tags.of(TAG_USAGE_STATISTICS_STATUS, status.value()), status,
-                    ctx -> getUsageStatisticsCached().getRegistryCountPerStatus().get(ctx));
+            Gauge.builder(USAGE_STATISTICS_REGISTRIES_STATUS, () -> {
+                Arc.initialize();
+                var ctx = Arc.container().requestContext();
+                ctx.activate();
+                try {
+                    return getUsageStatisticsCached().getRegistryCountPerStatus().get(status);
+                } finally {
+                    ctx.deactivate();
+                }
+            })
+            .tags(Tags.of(TAG_USAGE_STATISTICS_STATUS, status.value()))
+            .register(metrics);
         }
 
         for (RegistryInstanceTypeValueDto type : RegistryInstanceTypeValueDto.values()) {
-            metrics.gauge(USAGE_STATISTICS_REGISTRIES_TYPE, Tags.of(TAG_USAGE_STATISTICS_TYPE, type.value()), type,
-                    ctx -> getUsageStatisticsCached().getRegistryCountPerType().get(ctx));
+            Gauge.builder(USAGE_STATISTICS_REGISTRIES_TYPE, () -> {
+                Arc.initialize();
+                var ctx = Arc.container().requestContext();
+                ctx.activate();
+                try {
+                    return getUsageStatisticsCached().getRegistryCountPerType().get(type);
+                } finally {
+                    ctx.deactivate();
+                }
+            })
+            .tags(Tags.of(TAG_USAGE_STATISTICS_TYPE, type.value()))
+            .register(metrics);
         }
 
-        metrics.gauge(USAGE_STATISTICS_ACTIVE_USERS, DUMMY,
-                x -> getUsageStatisticsCached().getActiveUserCount());
-        metrics.gauge(USAGE_STATISTICS_ACTIVE_ORGANISATIONS, DUMMY,
-                x -> getUsageStatisticsCached().getActiveOrganisationCount());
+
+        Gauge.builder(USAGE_STATISTICS_ACTIVE_USERS, () -> {
+            Arc.initialize();
+            var ctx = Arc.container().requestContext();
+            ctx.activate();
+            try {
+                return getUsageStatisticsCached().getActiveUserCount();
+            } finally {
+                ctx.deactivate();
+            }
+        });
+
+        Gauge.builder(USAGE_STATISTICS_ACTIVE_ORGANISATIONS, () -> {
+            Arc.initialize();
+            var ctx = Arc.container().requestContext();
+            ctx.activate();
+            try {
+                return getUsageStatisticsCached().getActiveOrganisationCount();
+            } finally {
+                ctx.deactivate();
+            }
+        });
     }
 
     public synchronized UsageStatisticsDto getUsageStatisticsCached() {


### PR DESCRIPTION
This refactors the gauges in UsageMetrics to register them with the `strongReference` functionality , plus this is using quarkus cdi provider to explicitly start the CDI context. We did not see this issue here, but tenant manager was failing because CDI context was not active when loading gauges data.

I tested this, but testing from someone else might help to be safer