### PR TITLE
fix: remove unneccesary audit logging

### DIFF
--- a/core/src/main/java/org/bf2/srs/fleetmanager/AuditingServletFilter.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/AuditingServletFilter.java
@@ -57,8 +57,10 @@ public class AuditingServletFilter implements Filter {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
 
         // Activate Operation Context
-        if (opCtx.isContextDataLoaded())
+        if (opCtx.isContextDataLoaded()) {
             throw new IllegalStateException("Unexpected state: Operation Context is already loaded");
+        }
+
         opCtx.loadNewContextData();
 
         var req = (HttpServletRequest) request;

--- a/core/src/main/java/org/bf2/srs/fleetmanager/auth/AuthService.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/auth/AuthService.java
@@ -49,7 +49,7 @@ public class AuthService {
         AccountInfo accountInfo = new AccountInfo(defaultOrg, OWNER_PLACEHOLDER, false, OWNER_ID_PLACEHOLDER);
         if (SecurityUtil.isResolvable(securityIdentity)) {
             if (isTokenResolvable()) {
-                log.debug("Extracting account information from the authentication token");
+                log.trace("Extracting account information from the authentication token");
                 final String username = jwt.get().getName();
                 final String organizationId = (String) jwt.get().claim(organizationIdClaimName).orElse(defaultOrg);
                 final Long accountId = Long.parseLong((String) jwt.get().claim(accountIdClaim).orElse(defaultAccountId));

--- a/core/src/main/java/org/bf2/srs/fleetmanager/rest/service/impl/ErrorServiceImpl.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/rest/service/impl/ErrorServiceImpl.java
@@ -1,7 +1,6 @@
 package org.bf2.srs.fleetmanager.rest.service.impl;
 
 import org.bf2.srs.fleetmanager.common.errors.UserErrorCode;
-import org.bf2.srs.fleetmanager.common.operation.auditing.Audited;
 import org.bf2.srs.fleetmanager.rest.service.ErrorNotFoundException;
 import org.bf2.srs.fleetmanager.rest.service.ErrorService;
 import org.bf2.srs.fleetmanager.rest.service.model.ErrorDto;
@@ -14,8 +13,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.enterprise.context.ApplicationScoped;
 
-import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.KEY_USER_ERROR_ID;
-
 /**
  * @author Jakub Senko <jsenko@redhat.com>
  */
@@ -25,7 +22,6 @@ public class ErrorServiceImpl implements ErrorService {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Override
-    @Audited
     public ErrorListDto getErrors(Integer page, Integer size) {
         page = (page != null) ? page : 1;
         size = (size != null) ? size : 10;
@@ -48,7 +44,6 @@ public class ErrorServiceImpl implements ErrorService {
     }
 
     @Override
-    @Audited(extractParameters = {"0", KEY_USER_ERROR_ID})
     public ErrorDto getError(int id) throws ErrorNotFoundException {
         return Optional.ofNullable(UserErrorCode.getValueMap().get(id)).map(
                 uec -> ErrorDto.builder()

--- a/core/src/main/java/org/bf2/srs/fleetmanager/rest/service/impl/RegistryDeploymentServiceImpl.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/rest/service/impl/RegistryDeploymentServiceImpl.java
@@ -137,7 +137,6 @@ public class RegistryDeploymentServiceImpl implements RegistryDeploymentService 
     }
 
     @Override
-    @Audited
     public List<RegistryDeployment> getRegistryDeployments() {
         return storage.getAllRegistryDeployments().stream()
                 .map(convertRegistryDeployment::convert)
@@ -145,7 +144,6 @@ public class RegistryDeploymentServiceImpl implements RegistryDeploymentService 
     }
 
     @Override
-    @Audited(extractParameters = {"0", KEY_DEPLOYMENT_ID})
     public RegistryDeployment getRegistryDeployment(Long id) throws RegistryDeploymentNotFoundException {
         return storage.getRegistryDeploymentById(id)
                 .map(convertRegistryDeployment::convert)

--- a/core/src/main/java/org/bf2/srs/fleetmanager/rest/service/impl/RegistryServiceImpl.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/rest/service/impl/RegistryServiceImpl.java
@@ -141,7 +141,6 @@ public class RegistryServiceImpl implements RegistryService {
         return resourceType == ResourceType.REGISTRY_INSTANCE_STANDARD ? RegistryInstanceTypeValueDto.STANDARD : RegistryInstanceTypeValueDto.EVAL;
     }
 
-    @Audited
     @Override
     public RegistryListDto getRegistries(Integer page, Integer size, String orderBy, String search) {
         // Defaults
@@ -194,7 +193,6 @@ public class RegistryServiceImpl implements RegistryService {
 
     @Override
     @CheckReadPermissions
-    @Audited(extractParameters = {"0", KEY_REGISTRY_ID})
     public RegistryDto getRegistry(String registryId) throws RegistryNotFoundException {
         try {
             return storage.getRegistryById(registryId)
@@ -219,7 +217,6 @@ public class RegistryServiceImpl implements RegistryService {
     }
 
     @Override
-    @Audited
     public ServiceStatusDto getServiceStatus() {
         long total = storage.getRegistryCountTotal();
 

--- a/core/src/main/java/org/bf2/srs/fleetmanager/rest/service/impl/TaskServiceImpl.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/rest/service/impl/TaskServiceImpl.java
@@ -1,6 +1,5 @@
 package org.bf2.srs.fleetmanager.rest.service.impl;
 
-import org.bf2.srs.fleetmanager.common.operation.auditing.Audited;
 import org.bf2.srs.fleetmanager.execution.manager.TaskManager;
 import org.bf2.srs.fleetmanager.execution.manager.TaskNotFoundException;
 import org.bf2.srs.fleetmanager.rest.service.TaskService;
@@ -11,8 +10,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-
-import static org.bf2.srs.fleetmanager.common.operation.auditing.AuditingConstants.KEY_TASK_ID;
 
 /**
  * @author Jakub Senko <jsenko@redhat.com>
@@ -27,7 +24,6 @@ public class TaskServiceImpl implements TaskService {
     ConvertTask convertTask;
 
     @Override
-    @Audited
     public List<Task> getTasks() {
         return taskManager.getAllTasks().stream()
                 .map(convertTask::convert)
@@ -35,7 +31,6 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    @Audited(extractParameters = {"0", KEY_TASK_ID})
     public Task getTask(String id) throws TaskNotFoundException {
         return taskManager.getTaskById(id)
                 .map(convertTask::convert)

--- a/core/src/main/java/org/bf2/srs/fleetmanager/spi/mockImpl/MockTenantManagerService.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/spi/mockImpl/MockTenantManagerService.java
@@ -54,14 +54,12 @@ public class MockTenantManagerService implements TenantManagerService {
         return tenant;
     }
 
-    @Audited(extractParameters = {"1", KEY_TENANT_ID})
     @Override
     public Optional<Tenant> getTenantById(TenantManagerConfig tm, String tenantId) {
         init(tm);
         return Optional.ofNullable(testData.get(tm).get(tenantId));
     }
 
-    @Audited
     @Override
     public List<Tenant> getAllTenants(TenantManagerConfig tm) {
         init(tm);


### PR DESCRIPTION
this PR removes a bunch of audit logs. Audit logs are meant to be used for write operations.