### PR TITLE
clean up srs rest api doc and regenerate

### DIFF
--- a/core/src/main/java/org/bf2/srs/fleetmanager/rest/publicapi/ApiResource.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/rest/publicapi/ApiResource.java
@@ -1,7 +1,5 @@
 package org.bf2.srs.fleetmanager.rest.publicapi;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -10,78 +8,66 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-
 import org.bf2.srs.fleetmanager.rest.publicapi.beans.Error;
 import org.bf2.srs.fleetmanager.rest.publicapi.beans.ErrorList;
 import org.bf2.srs.fleetmanager.rest.publicapi.beans.Registry;
 import org.bf2.srs.fleetmanager.rest.publicapi.beans.RegistryCreate;
 import org.bf2.srs.fleetmanager.rest.publicapi.beans.RegistryList;
 import org.bf2.srs.fleetmanager.rest.publicapi.beans.ServiceStatus;
-import org.bf2.srs.fleetmanager.rest.service.ErrorNotFoundException;
-import org.bf2.srs.fleetmanager.spi.TooManyEvalInstancesForUserException;
-import org.bf2.srs.fleetmanager.spi.EvalInstancesNotAllowedException;
-import org.bf2.srs.fleetmanager.spi.ResourceLimitReachedException;
-import org.bf2.srs.fleetmanager.spi.TermsRequiredException;
-import org.bf2.srs.fleetmanager.spi.TooManyInstancesException;
-import org.bf2.srs.fleetmanager.storage.RegistryNotFoundException;
-import org.bf2.srs.fleetmanager.storage.RegistryStorageConflictException;
 
 /**
  * A JAX-RS interface.  An implementation of this interface must be provided.
  */
 @Path("/api")
 public interface ApiResource {
-    /**
-     *
-     */
-    @Path("/serviceregistry_mgmt/v1/registries")
-    @GET
-    @Produces("application/json")
-    RegistryList getRegistries(@Min(1) @QueryParam("page") Integer page, @Min(1) @Max(500) @QueryParam("size") Integer size,
-                               @QueryParam("orderBy") String orderBy, @QueryParam("search") String search);
+  /**
+   *
+   */
+  @Path("/serviceregistry_mgmt/v1/registries")
+  @GET
+  @Produces("application/json")
+  RegistryList getRegistries(@QueryParam("page") Integer page, @QueryParam("size") Integer size,
+      @QueryParam("orderBy") String orderBy, @QueryParam("search") String search);
 
-    /**
-     *
-     */
-    @Path("/serviceregistry_mgmt/v1/registries")
-    @POST
-    @Produces("application/json")
-    @Consumes("application/json")
-    Registry createRegistry(RegistryCreate data)
-            throws RegistryStorageConflictException, TermsRequiredException, ResourceLimitReachedException,
-            EvalInstancesNotAllowedException, TooManyEvalInstancesForUserException, TooManyInstancesException;
+  /**
+   *
+   */
+  @Path("/serviceregistry_mgmt/v1/registries")
+  @POST
+  @Produces("application/json")
+  @Consumes("application/json")
+  Registry createRegistry(RegistryCreate data);
 
-    /**
-     * Gets the details of a single instance of a `Registry`.
-     */
-    @Path("/serviceregistry_mgmt/v1/registries/{id}")
-    @GET
-    @Produces("application/json")
-    Registry getRegistry(@PathParam("id") String id) throws RegistryNotFoundException;
+  /**
+   * Gets the details of a single instance of a `Registry`.
+   */
+  @Path("/serviceregistry_mgmt/v1/registries/{id}")
+  @GET
+  @Produces("application/json")
+  Registry getRegistry(@PathParam("id") String id);
 
-    /**
-     * Deletes an existing `Registry`.
-     */
-    @Path("/serviceregistry_mgmt/v1/registries/{id}")
-    @DELETE
-    void deleteRegistry(@PathParam("id") String id) throws RegistryStorageConflictException, RegistryNotFoundException;
+  /**
+   * Deletes an existing `Registry` instance and all of the data that it stores. Important: Users should export the registry data before deleting the instance, e.g., using the Service Registry web console or the Apicurio Registry core REST API.
+   */
+  @Path("/serviceregistry_mgmt/v1/registries/{id}")
+  @DELETE
+  void deleteRegistry(@PathParam("id") String id);
 
-    /**
-     *
-     */
-    @Path("/serviceregistry_mgmt/v1/errors/{id}")
-    @GET
-    @Produces("application/json")
-    Error getError(@PathParam("id") Integer id) throws ErrorNotFoundException;
+  @Path("/serviceregistry_mgmt/v1/errors")
+  @GET
+  @Produces("application/json")
+  ErrorList getErrors(@QueryParam("page") Integer page, @QueryParam("size") Integer size);
 
-    @Path("/serviceregistry_mgmt/v1/errors")
-    @GET
-    @Produces("application/json")
-    ErrorList getErrors(@Min(1) @QueryParam("page") Integer page, @Min(1) @Max(500) @QueryParam("size") Integer size);
+  @Path("/serviceregistry_mgmt/v1/status")
+  @GET
+  @Produces("application/json")
+  ServiceStatus getServiceStatus();
 
-    @Path("/serviceregistry_mgmt/v1/status")
-    @GET
-    @Produces("application/json")
-    ServiceStatus getServiceStatus();
-
+  /**
+   *
+   */
+  @Path("/serviceregistry_mgmt/v1/errors/{id}")
+  @GET
+  @Produces("application/json")
+  Error getError(@PathParam("id") Integer id);
 }

--- a/core/src/main/java/org/bf2/srs/fleetmanager/rest/publicapi/beans/Registry.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/rest/publicapi/beans/Registry.java
@@ -2,9 +2,7 @@
 package org.bf2.srs.fleetmanager.rest.publicapi.beans;
 
 import java.util.Date;
-
 import javax.annotation.processing.Generated;
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -13,10 +11,10 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
 /**
- * Root Type for Registry
+ * Root type for `Registry` instance
  * <p>
  * Service Registry instance within a multi-tenant deployment.
- *
+ * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
@@ -38,9 +36,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class Registry {
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("id")
     private String id;
@@ -50,61 +48,61 @@ public class Registry {
     private String href;
     /**
      * "accepted": Registry status when accepted for processing.
-     *
+     * 
      * "provisioning": Registry status when provisioning a new instance.
-     *
+     * 
      * "ready": Registry status when ready for use.
-     *
-     * "failed": Registry status when the provisioning failed. When removing a Registry in this state,
+     * 
+     * "failed": Registry status when the provisioning failed. When removing a registry instance in this state,
      * the status transitions directly to "deleting".
-     *
-     *
+     * 
+     * 
      * "deprovision": Registry status when accepted for deprovisioning.
-     *
+     * 
      * "deleting": Registry status when deprovisioning.
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("status")
-    @JsonPropertyDescription("\"accepted\": Registry status when accepted for processing.\n\n\"provisioning\": Registry status when provisioning a new instance.\n\n\"ready\": Registry status when ready for use.\n\n\"failed\": Registry status when the provisioning failed. When removing a Registry in this state,\nthe status transitions directly to \"deleting\".\n\n\n\"deprovision\": Registry status when accepted for deprovisioning.\n\n\"deleting\": Registry status when deprovisioning.\n")
+    @JsonPropertyDescription("\"accepted\": Registry status when accepted for processing.\n\n\"provisioning\": Registry status when provisioning a new instance.\n\n\"ready\": Registry status when ready for use.\n\n\"failed\": Registry status when the provisioning failed. When removing a registry instance in this state,\nthe status transitions directly to \"deleting\".\n\n\n\"deprovision\": Registry status when accepted for deprovisioning.\n\n\"deleting\": Registry status when deprovisioning.\n")
     private RegistryStatusValue status;
     @JsonProperty("registryUrl")
     private String registryUrl;
     @JsonProperty("browserUrl")
     private String browserUrl;
     /**
-     * User-defined Registry name. Does not have to be unique.
-     *
+     * User-defined `Registry` instance name. Does not have to be unique.
+     * 
      */
     @JsonProperty("name")
-    @JsonPropertyDescription("User-defined Registry name. Does not have to be unique.")
+    @JsonPropertyDescription("User-defined `Registry` instance name. Does not have to be unique.")
     private String name;
     /**
      * Identifier of a multi-tenant deployment, where this Service Registry instance resides.
-     *
+     * 
      */
     @JsonProperty("registryDeploymentId")
     @JsonPropertyDescription("Identifier of a multi-tenant deployment, where this Service Registry instance resides.")
     private Integer registryDeploymentId;
     /**
      * Registry instance owner
-     *
+     * 
      */
     @JsonProperty("owner")
     @JsonPropertyDescription("Registry instance owner")
     private String owner;
     /**
-     * Description of the Registry instance.
-     *
+     * Description of the registry instance.
+     * 
      */
     @JsonProperty("description")
-    @JsonPropertyDescription("Description of the Registry instance.")
+    @JsonPropertyDescription("Description of the registry instance.")
     private String description;
     /**
      * ISO 8601 UTC timestamp.
      * (Required)
-     *
+     * 
      */
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
     @JsonProperty("created_at")
@@ -113,28 +111,28 @@ public class Registry {
     /**
      * ISO 8601 UTC timestamp.
      * (Required)
-     *
+     * 
      */
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
     @JsonProperty("updated_at")
     @JsonPropertyDescription("ISO 8601 UTC timestamp.")
     private Date updatedAt;
     /**
-     * "standard": Standard, full-featured Registry instance
-     *
+     * "standard": Standard, full-featured registry instance
+     * 
      * "eval": Evaluation (Trial) instance, provided for a limited time
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("instance_type")
-    @JsonPropertyDescription("\"standard\": Standard, full-featured Registry instance\n\n\"eval\": Evaluation (Trial) instance, provided for a limited time\n")
+    @JsonPropertyDescription("\"standard\": Standard, full-featured registry instance\n\n\"eval\": Evaluation (Trial) instance, provided for a limited time\n")
     private RegistryInstanceTypeValue instanceType;
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("id")
     public String getId() {
@@ -142,9 +140,9 @@ public class Registry {
     }
 
     /**
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("id")
     public void setId(String id) {
@@ -173,21 +171,21 @@ public class Registry {
 
     /**
      * "accepted": Registry status when accepted for processing.
-     *
+     * 
      * "provisioning": Registry status when provisioning a new instance.
-     *
+     * 
      * "ready": Registry status when ready for use.
-     *
-     * "failed": Registry status when the provisioning failed. When removing a Registry in this state,
+     * 
+     * "failed": Registry status when the provisioning failed. When removing a registry instance in this state,
      * the status transitions directly to "deleting".
-     *
-     *
+     * 
+     * 
      * "deprovision": Registry status when accepted for deprovisioning.
-     *
+     * 
      * "deleting": Registry status when deprovisioning.
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("status")
     public RegistryStatusValue getStatus() {
@@ -196,21 +194,21 @@ public class Registry {
 
     /**
      * "accepted": Registry status when accepted for processing.
-     *
+     * 
      * "provisioning": Registry status when provisioning a new instance.
-     *
+     * 
      * "ready": Registry status when ready for use.
-     *
-     * "failed": Registry status when the provisioning failed. When removing a Registry in this state,
+     * 
+     * "failed": Registry status when the provisioning failed. When removing a registry instance in this state,
      * the status transitions directly to "deleting".
-     *
-     *
+     * 
+     * 
      * "deprovision": Registry status when accepted for deprovisioning.
-     *
+     * 
      * "deleting": Registry status when deprovisioning.
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("status")
     public void setStatus(RegistryStatusValue status) {
@@ -238,8 +236,8 @@ public class Registry {
     }
 
     /**
-     * User-defined Registry name. Does not have to be unique.
-     *
+     * User-defined `Registry` instance name. Does not have to be unique.
+     * 
      */
     @JsonProperty("name")
     public String getName() {
@@ -247,8 +245,8 @@ public class Registry {
     }
 
     /**
-     * User-defined Registry name. Does not have to be unique.
-     *
+     * User-defined `Registry` instance name. Does not have to be unique.
+     * 
      */
     @JsonProperty("name")
     public void setName(String name) {
@@ -257,7 +255,7 @@ public class Registry {
 
     /**
      * Identifier of a multi-tenant deployment, where this Service Registry instance resides.
-     *
+     * 
      */
     @JsonProperty("registryDeploymentId")
     public Integer getRegistryDeploymentId() {
@@ -266,7 +264,7 @@ public class Registry {
 
     /**
      * Identifier of a multi-tenant deployment, where this Service Registry instance resides.
-     *
+     * 
      */
     @JsonProperty("registryDeploymentId")
     public void setRegistryDeploymentId(Integer registryDeploymentId) {
@@ -275,7 +273,7 @@ public class Registry {
 
     /**
      * Registry instance owner
-     *
+     * 
      */
     @JsonProperty("owner")
     public String getOwner() {
@@ -284,7 +282,7 @@ public class Registry {
 
     /**
      * Registry instance owner
-     *
+     * 
      */
     @JsonProperty("owner")
     public void setOwner(String owner) {
@@ -292,8 +290,8 @@ public class Registry {
     }
 
     /**
-     * Description of the Registry instance.
-     *
+     * Description of the registry instance.
+     * 
      */
     @JsonProperty("description")
     public String getDescription() {
@@ -301,8 +299,8 @@ public class Registry {
     }
 
     /**
-     * Description of the Registry instance.
-     *
+     * Description of the registry instance.
+     * 
      */
     @JsonProperty("description")
     public void setDescription(String description) {
@@ -312,7 +310,7 @@ public class Registry {
     /**
      * ISO 8601 UTC timestamp.
      * (Required)
-     *
+     * 
      */
     @JsonProperty("created_at")
     public Date getCreatedAt() {
@@ -322,7 +320,7 @@ public class Registry {
     /**
      * ISO 8601 UTC timestamp.
      * (Required)
-     *
+     * 
      */
     @JsonProperty("created_at")
     public void setCreatedAt(Date createdAt) {
@@ -332,7 +330,7 @@ public class Registry {
     /**
      * ISO 8601 UTC timestamp.
      * (Required)
-     *
+     * 
      */
     @JsonProperty("updated_at")
     public Date getUpdatedAt() {
@@ -342,7 +340,7 @@ public class Registry {
     /**
      * ISO 8601 UTC timestamp.
      * (Required)
-     *
+     * 
      */
     @JsonProperty("updated_at")
     public void setUpdatedAt(Date updatedAt) {
@@ -350,12 +348,12 @@ public class Registry {
     }
 
     /**
-     * "standard": Standard, full-featured Registry instance
-     *
+     * "standard": Standard, full-featured registry instance
+     * 
      * "eval": Evaluation (Trial) instance, provided for a limited time
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("instance_type")
     public RegistryInstanceTypeValue getInstanceType() {
@@ -363,12 +361,12 @@ public class Registry {
     }
 
     /**
-     * "standard": Standard, full-featured Registry instance
-     *
+     * "standard": Standard, full-featured registry instance
+     * 
      * "eval": Evaluation (Trial) instance, provided for a limited time
-     *
+     * 
      * (Required)
-     *
+     * 
      */
     @JsonProperty("instance_type")
     public void setInstanceType(RegistryInstanceTypeValue instanceType) {

--- a/core/src/main/java/org/bf2/srs/fleetmanager/rest/publicapi/beans/RegistryCreate.java
+++ b/core/src/main/java/org/bf2/srs/fleetmanager/rest/publicapi/beans/RegistryCreate.java
@@ -9,9 +9,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 
 /**
- * Root Type for RegistryCreate
+ * Root type for RegistryCreate
  * <p>
- * Information used to create a new Service Registry instance within a multi-tenant deployment.
+ * Information used to create a new Service Registry instance in a multi-tenant deployment.
  * 
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -23,22 +23,22 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 public class RegistryCreate {
 
     /**
-     * User-defined Registry name. Required. Does not have to be unique.
+     * User-defined `Registry` instance name. Required. Does not have to be unique.
      * 
      */
     @JsonProperty("name")
-    @JsonPropertyDescription("User-defined Registry name. Required. Does not have to be unique.")
+    @JsonPropertyDescription("User-defined `Registry` instance name. Required. Does not have to be unique.")
     private String name;
     /**
-     * User-provided description of the new Registry instance. Not required.
+     * User-provided description of the new `Registry` instance. Not required.
      * 
      */
     @JsonProperty("description")
-    @JsonPropertyDescription("User-provided description of the new Registry instance. Not required.")
+    @JsonPropertyDescription("User-provided description of the new `Registry` instance. Not required.")
     private String description;
 
     /**
-     * User-defined Registry name. Required. Does not have to be unique.
+     * User-defined `Registry` instance name. Required. Does not have to be unique.
      * 
      */
     @JsonProperty("name")
@@ -47,7 +47,7 @@ public class RegistryCreate {
     }
 
     /**
-     * User-defined Registry name. Required. Does not have to be unique.
+     * User-defined `Registry` instance name. Required. Does not have to be unique.
      * 
      */
     @JsonProperty("name")
@@ -56,7 +56,7 @@ public class RegistryCreate {
     }
 
     /**
-     * User-provided description of the new Registry instance. Not required.
+     * User-provided description of the new `Registry` instance. Not required.
      * 
      */
     @JsonProperty("description")
@@ -65,7 +65,7 @@ public class RegistryCreate {
     }
 
     /**
-     * User-provided description of the new Registry instance. Not required.
+     * User-provided description of the new `Registry` instance. Not required.
      * 
      */
     @JsonProperty("description")

--- a/core/src/main/resources/srs-fleet-manager.json
+++ b/core/src/main/resources/srs-fleet-manager.json
@@ -1,876 +1,875 @@
 {
-  "openapi": "3.0.2",
-  "info": {
-    "title": "Service Registry Fleet Manager",
-    "version": "0.0.6",
-    "description": "Managed Service Registry cloud.redhat.com API Management API that lets you create new registry instances. Registry is a datastore for standard event schemas and API designs. Service Registry enables developers to manage and share the structure of their data using a REST interface. For example, client applications can dynamically push or pull the latest updates to or from the registry without needing to redeploy. Registry is an Managed version of upstream project called Apicurio Registry. Apicurio Registry also enables developers to create rules that govern how registry content can evolve over time. For example, this includes rules for content validation and version compatibility.",
-    "contact": {
-      "name": "Cloud Red Hat",
-      "url": "https://cloud.redhat.com/beta/application-services/streams/",
-      "email": "rhosak-eval-support@redhat.com"
-    },
-    "license": {
-      "name": "Apache 2.0",
-      "url": "https://www.apache.org/licenses/LICENSE-2.0"
-    }
-  },
-  "servers": [
-    {
-      "url": "https://api.openshift.com",
-      "description": "Main (production) server"
-    },
-    {
-      "url": "https://api.stage.openshift.com",
-      "description": "Staging server"
-    },
-    {
-      "url": "http://localhost:8000",
-      "description": "localhost"
-    },
-    {
-      "url": "/",
-      "description": "current domain"
-    }
-  ],
-  "paths": {
-    "/api/serviceregistry_mgmt/v1/registries": {
-      "summary": "Manage the list of all registries.",
-      "description": "",
-      "get": {
-        "tags": [
-          "Registries"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/page"
-          },
-          {
-            "$ref": "#/components/parameters/size"
-          },
-          {
-            "$ref": "#/components/parameters/orderBy"
-          },
-          {
-            "$ref": "#/components/parameters/search"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RegistryList"
-                }
-              }
-            },
-            "description": "A successful response."
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "401Example": {
-                    "$ref": "#/components/examples/401Example"
-                  }
-                }
-              }
-            },
-            "description": "Auth token is invalid"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "403Example": {
-                    "$ref": "#/components/examples/403Example"
-                  }
-                }
-              }
-            },
-            "description": "User not authorized to access the service."
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "500Example": {
-                    "$ref": "#/components/examples/500Example"
-                  }
-                }
-              }
-            },
-            "description": "Unexpected error occurred"
-          }
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Service Registry Fleet Manager",
+        "version": "0.0.6",
+        "description": "Service Registry Fleet Manager is a REST API for managing Service Registry instances. Service Registry is a datastore for event schemas and API designs, which is based on the open source Apicurio Registry project.",
+        "contact": {
+            "name": "Red Hat Hybrid Cloud Console",
+            "url": "https://console.redhat.com/application-services/service-registry/",
+            "email": "rhosak-eval-support@redhat.com"
         },
-        "security": [
-          {
-            "Bearer": [
-            ]
-          }
-        ],
-        "operationId": "getRegistries",
-        "summary": "Get the list of all registries.",
-        "description": ""
-      },
-      "post": {
-        "requestBody": {
-          "description": "A new `Registry` to be created.",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RegistryCreate"
-              }
-            }
-          },
-          "required": true
-        },
-        "tags": [
-          "Registries"
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Registry"
-                }
-              }
-            },
-            "description": "A successful response. The full request to create a new `Registry` is processed asynchronously. User should verify the result of the operation by reading the `status` property of the created `Registry` entity."
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "401Example": {
-                    "$ref": "#/components/examples/401Example"
-                  }
-                }
-              }
-            },
-            "description": "Auth token is invalid"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "403Example": {
-                    "$ref": "#/components/examples/403Example"
-                  }
-                }
-              }
-            },
-            "description": "User not authorized to access the service."
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "500Example": {
-                    "$ref": "#/components/examples/500Example"
-                  }
-                }
-              }
-            },
-            "description": "Unexpected error occurred"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-            ]
-          }
-        ],
-        "operationId": "createRegistry",
-        "summary": "Create a new Registry instance",
-        "description": ""
-      }
+        "license": {
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
     },
-    "/api/serviceregistry_mgmt/v1/registries/{id}": {
-      "summary": "Manage a specific Registry.",
-      "description": "",
-      "get": {
-        "tags": [
-          "Registries"
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Registry"
-                }
-              }
-            },
-            "description": "Successful response - returns a single `Registry`."
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "401Example": {
-                    "$ref": "#/components/examples/401Example"
-                  }
-                }
-              }
-            },
-            "description": "Auth token is invalid"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "403Example": {
-                    "$ref": "#/components/examples/403Example"
-                  }
-                }
-              }
-            },
-            "description": "User not authorized to access the service."
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "404Example": {
-                    "$ref": "#/components/examples/404Example"
-                  }
-                }
-              }
-            },
-            "description": "No service registry with specified id exists"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-            ]
-          }
-        ],
-        "operationId": "getRegistry",
-        "summary": "Get a Registry",
-        "description": "Gets the details of a single instance of a `Registry`."
-      },
-      "delete": {
-        "tags": [
-          "Registries"
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful response."
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "401Example": {
-                    "$ref": "#/components/examples/401Example"
-                  }
-                }
-              }
-            },
-            "description": "Auth token is invalid"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "403Example": {
-                    "$ref": "#/components/examples/403Example"
-                  }
-                }
-              }
-            },
-            "description": "User not authorized to access the service."
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "404Example": {
-                    "$ref": "#/components/examples/404Example"
-                  }
-                }
-              }
-            },
-            "description": "No Service Registry with specified id exists"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-            ]
-          }
-        ],
-        "operationId": "deleteRegistry",
-        "summary": "Delete a Registry",
-        "description": "Deletes an existing `Registry`."
-      },
-      "parameters": [
+    "servers": [
         {
-          "name": "id",
-          "description": "A unique identifier for a `Registry`.",
-          "schema": {
-            "type": "string"
-          },
-          "in": "path",
-          "required": true
-        }
-      ]
-    },
-    "/api/serviceregistry_mgmt/v1/errors/{id}": {
-      "summary": "Get information about a specific error type.",
-      "get": {
-        "tags": [
-          "Errors"
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            },
-            "description": "Successful response - returns a single `Error`."
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "404Example": {
-                    "$ref": "#/components/examples/404Example"
-                  }
-                }
-              }
-            },
-            "description": "No service registry with specified id exists"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                },
-                "examples": {
-                  "500Example": {
-                    "$ref": "#/components/examples/500Example"
-                  }
-                }
-              }
-            },
-            "description": "Unexpected error occurred"
-          }
+            "url": "https://api.openshift.com",
+            "description": "Main (production) server"
         },
-        "security": [],
-        "operationId": "getError",
-        "summary": "Get information about a specific error type.",
-        "description": ""
-      },
-      "parameters": [
         {
-          "name": "id",
-          "description": "A unique identifier for an error type.",
-          "schema": {
-            "minimum": 1,
-            "type": "integer"
-          },
-          "in": "path",
-          "required": true
+            "url": "https://api.stage.openshift.com",
+            "description": "Staging server"
+        },
+        {
+            "url": "http://localhost:8000",
+            "description": "localhost"
+        },
+        {
+            "url": "/",
+            "description": "current domain"
         }
-      ]
-    },
-    "/api/serviceregistry_mgmt/v1/errors": {
-      "summary": "Get the list of all errors.",
-      "get": {
-        "tags": [
-          "Errors"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/page"
-          },
-          {
-            "$ref": "#/components/parameters/size"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorList"
-                }
-              }
-            },
-            "description": "A successful response."
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
+    ],
+    "paths": {
+        "/api/serviceregistry_mgmt/v1/registries": {
+            "summary": "Manage the list of all Registry instances",
+            "description": "",
+            "get": {
+                "tags": [
+                    "Registries"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/size"
+                    },
+                    {
+                        "$ref": "#/components/parameters/orderBy"
+                    },
+                    {
+                        "$ref": "#/components/parameters/search"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RegistryList"
+                                }
+                            }
+                        },
+                        "description": "A successful response."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "401Example": {
+                                        "$ref": "#/components/examples/401Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Auth token is invalid."
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "403Example": {
+                                        "$ref": "#/components/examples/403Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "User is not authorized to access the service."
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "500Example": {
+                                        "$ref": "#/components/examples/500Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Unexpected error occurred."
+                    }
                 },
-                "examples": {
-                  "500Example": {
-                    "$ref": "#/components/examples/500Example"
-                  }
-                }
-              }
+                "security": [
+                    {
+                        "Bearer": [
+                        ]
+                    }
+                ],
+                "operationId": "getRegistries",
+                "summary": "Get the list of all Registry instances",
+                "description": ""
             },
-            "description": "Unexpected error occurred"
-          }
+            "post": {
+                "requestBody": {
+                    "description": "A new `Registry` instance to be created.",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RegistryCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "tags": [
+                    "Registries"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Registry"
+                                }
+                            }
+                        },
+                        "description": "A successful response. The full request to create a new `Registry` instance is processed asynchronously. The user should verify the result of the operation by reading the `status` property of the created `Registry` instance."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "401Example": {
+                                        "$ref": "#/components/examples/401Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Auth token is invalid."
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "403Example": {
+                                        "$ref": "#/components/examples/403Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "User is not authorized to access the service."
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "500Example": {
+                                        "$ref": "#/components/examples/500Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Unexpected error occurred."
+                    }
+                },
+                "security": [
+                    {
+                        "Bearer": [
+                        ]
+                    }
+                ],
+                "operationId": "createRegistry",
+                "summary": "Create a new Registry instance",
+                "description": ""
+            }
         },
-        "security": [],
-        "operationId": "getErrors",
-        "summary": "Get the list of all errors."
-      }
-    },
-    "/api/serviceregistry_mgmt/v1/status": {
-      "summary": "Retrieves the status of resources e.g whether we have reached maximum service capacity",
-      "get": {
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceStatus"
-                }
-              }
+        "/api/serviceregistry_mgmt/v1/registries/{id}": {
+            "summary": "Manage a specific Registry instance",
+            "description": "",
+            "get": {
+                "tags": [
+                    "Registries"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Registry"
+                                }
+                            }
+                        },
+                        "description": "Successful response - returns a single `Registry` instance."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "401Example": {
+                                        "$ref": "#/components/examples/401Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Auth token is invalid."
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "403Example": {
+                                        "$ref": "#/components/examples/403Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "User is not authorized to access the service."
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "404Example": {
+                                        "$ref": "#/components/examples/404Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "No Service Registry instance with the specified id exists."
+                    }
+                },
+                "security": [
+                    {
+                        "Bearer": [
+                        ]
+                    }
+                ],
+                "operationId": "getRegistry",
+                "summary": "Get a Registry instance",
+                "description": "Gets the details of a single instance of a `Registry`."
             },
-            "description": "Successfully returned service status"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
+            "delete": {
+                "tags": [
+                    "Registries"
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successful response."
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "401Example": {
+                                        "$ref": "#/components/examples/401Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Auth token is invalid."
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "403Example": {
+                                        "$ref": "#/components/examples/403Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "User is not authorized to access the service."
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "404Example": {
+                                        "$ref": "#/components/examples/404Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "No Service Registry instance with the specified id exists."
+                    }
+                },
+                "security": [
+                    {
+                        "Bearer": [
+                        ]
+                    }
+                ],
+                "operationId": "deleteRegistry",
+                "summary": "Delete a Registry instance",
+                "description": "Deletes an existing `Registry` instance and all of the data that it stores. Important: Users should export the registry data before deleting the instance, e.g., using the Service Registry web console or the Apicurio Registry core REST API."
             },
-            "description": "Internal error retrieving service status."
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
+            "parameters": [
+                {
+                    "name": "id",
+                    "description": "A unique identifier for a `Registry` instance.",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "in": "path",
+                    "required": true
+                }
             ]
-          }
-        ],
-        "operationId": "getServiceStatus"
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "Error": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ObjectReference"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "reason": {
-                "type": "string"
-              },
-              "operation_id": {
-                "type": "string"
-              }
+        },
+        "/api/serviceregistry_mgmt/v1/errors": {
+            "summary": "Get the list of all errors",
+            "get": {
+                "tags": [
+                    "Errors"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/page"
+                    },
+                    {
+                        "$ref": "#/components/parameters/size"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorList"
+                                }
+                            }
+                        },
+                        "description": "A successful response."
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "500Example": {
+                                        "$ref": "#/components/examples/500Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Unexpected error occurred."
+                    }
+                },
+                "operationId": "getErrors",
+                "summary": "Get the list of all errors"
             }
-          }
-        ]
-      },
-      "ErrorList": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/List"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "items": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
+        },
+        "/api/serviceregistry_mgmt/v1/status": {
+            "summary": "Retrieves the status of resources, e.g., whether we have reached maximum service capacity.",
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ServiceStatus"
+                                }
+                            }
+                        },
+                        "description": "Successfully returned service status"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "description": "Internal error retrieving service status."
+                    }
+                },
+                "security": [
+                    {
+                        "Bearer": [
+                        ]
+                    }
+                ],
+                "operationId": "getServiceStatus",
+                "summary": "Get the service status"
             }
-          }
-        ]
-      },
-      "List": {
-        "required": [
-          "kind",
-          "page",
-          "size",
-          "total",
-          "items"
-        ],
-        "type": "object",
-        "properties": {
-          "kind": {
-            "type": "string"
-          },
-          "page": {
-            "type": "integer"
-          },
-          "size": {
-            "type": "integer"
-          },
-          "total": {
-            "type": "integer"
-          }
-        }
-      },
-      "ObjectReference": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "kind": {
-            "type": "string"
-          },
-          "href": {
-            "type": "string"
-          }
-        }
-      },
-      "Registry": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ObjectReference"
-          },
-          {
-            "title": "Root Type for Registry",
-            "description": "Service Registry instance within a multi-tenant deployment.",
-            "required": [
-              "id",
-              "status",
-              "created_at",
-              "updated_at",
-              "instance_type"
-            ],
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
-              },
-              "status": {
-                "$ref": "#/components/schemas/RegistryStatusValue"
-              },
-              "registryUrl": {
-                "type": "string"
-              },
-              "browserUrl": {
-                "type": "string"
-              },
-              "name": {
-                "description": "User-defined Registry name. Does not have to be unique.",
-                "type": "string"
-              },
-              "registryDeploymentId": {
-                "description": "Identifier of a multi-tenant deployment, where this Service Registry instance resides.",
-                "type": "integer"
-              },
-              "owner": {
-                "description": "Registry instance owner",
-                "type": "string"
-              },
-              "description": {
-                "description": "Description of the Registry instance.",
-                "type": "string"
-              },
-              "created_at": {
-                "format": "date-time",
-                "description": "ISO 8601 UTC timestamp.",
-                "type": "string"
-              },
-              "updated_at": {
-                "format": "date-time",
-                "description": "ISO 8601 UTC timestamp.",
-                "type": "string"
-              },
-              "instance_type": {
-                "$ref": "#/components/schemas/RegistryInstanceTypeValue",
-                "description": "Type of the Registry instance. This will determine functional and/or non-functional features provided by the instance."
-              }
+        },
+        "/api/serviceregistry_mgmt/v1/errors/{id}": {
+            "summary": "Get information about a specific error type",
+            "get": {
+                "tags": [
+                    "Errors"
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "description": "Successful response - returns a single `Error`."
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "404Example": {
+                                        "$ref": "#/components/examples/404Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "No Service Registry instance with the specified id exists."
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                },
+                                "examples": {
+                                    "500Example": {
+                                        "$ref": "#/components/examples/500Example"
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Unexpected error occurred."
+                    }
+                },
+                "operationId": "getError",
+                "summary": "Get information about a specific error type",
+                "description": ""
             },
-            "example": {
-              "id": "42",
-              "name": "my-registry",
-              "registryUrl": "https://registry.apps.example.com/t/5213600b-afc9-487e-8cc3-339f4248d706",
-              "browserUrl": "https://registry-ui.apps.example.com/t/5213600b-afc9-487e-8cc3-339f4248d706",
-              "status": {
-                "status": "PROVISIONING",
-                "lastUpdated": "2021-05-04T12:34:56Z"
-              },
-              "registryDeploymentId": 1,
-              "owner": "ownername"
-            }
-          }
-        ]
-      },
-      "RegistryCreate": {
-        "title": "Root Type for RegistryCreate",
-        "description": "Information used to create a new Service Registry instance within a multi-tenant deployment.",
-        "type": "object",
-        "properties": {
-          "name": {
-            "description": "User-defined Registry name. Required. Does not have to be unique.",
-            "maxLength": 32,
-            "minLength": 1,
-            "pattern": "[a-z]([a-z0-9\\-]*[a-z0-9])?",
-            "type": "string"
-          },
-          "description": {
-            "description": "User-provided description of the new Registry instance. Not required.",
-            "maxLength": 255,
-            "type": "string"
-          }
-        },
-        "example": {
-          "name": "my-registry",
-          "description": "This instance is for development environment only."
-        }
-      },
-      "RegistryList": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/List"
-          },
-          {
-            "required": [
-              "items"
-            ],
-            "type": "object",
-            "properties": {
-              "items": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Registry"
+            "parameters": [
+                {
+                    "name": "id",
+                    "description": "A unique identifier for an error type.",
+                    "schema": {
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
                 }
-              }
+            ]
+        }
+    },
+    "components": {
+        "schemas": {
+            "Error": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ObjectReference"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "code": {
+                                "type": "string"
+                            },
+                            "reason": {
+                                "type": "string"
+                            },
+                            "operation_id": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             },
-            "example": {
-              "kind": "RegistryList",
-              "page": "1",
-              "size": "1",
-              "total": "1",
-              "item": {
-                "id": "llmNteR4P7waRp5nJIReG",
-                "kind": "serviceregistry",
-                "href": "/api/serviceregistry_mgmt/v1/registries/llmNteR4P7waRp5nJIReG",
-                "name": "sample-registry",
-                "status": "ready",
-                "owner": "some_id",
-                "registryUrl": "https://somehost:433/t/12345",
-                "browserUrl": "https://someuihost:443/registries/12345"
-              }
+            "ErrorList": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/List"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            "List": {
+                "required": [
+                    "kind",
+                    "page",
+                    "size",
+                    "total",
+                    "items"
+                ],
+                "type": "object",
+                "properties": {
+                    "kind": {
+                        "type": "string"
+                    },
+                    "page": {
+                        "type": "integer"
+                    },
+                    "size": {
+                        "type": "integer"
+                    },
+                    "total": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "ObjectReference": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "type": "string"
+                    },
+                    "href": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Registry": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ObjectReference"
+                    },
+                    {
+                        "title": "Root type for `Registry` instance",
+                        "description": "Service Registry instance within a multi-tenant deployment.",
+                        "required": [
+                            "id",
+                            "status",
+                            "created_at",
+                            "updated_at",
+                            "instance_type"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "status": {
+                                "$ref": "#/components/schemas/RegistryStatusValue"
+                            },
+                            "registryUrl": {
+                                "type": "string"
+                            },
+                            "browserUrl": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "description": "User-defined `Registry` instance name. Does not have to be unique.",
+                                "type": "string"
+                            },
+                            "registryDeploymentId": {
+                                "description": "Identifier of a multi-tenant deployment, where this Service Registry instance resides.",
+                                "type": "integer"
+                            },
+                            "owner": {
+                                "description": "Registry instance owner",
+                                "type": "string"
+                            },
+                            "description": {
+                                "description": "Description of the registry instance.",
+                                "type": "string"
+                            },
+                            "created_at": {
+                                "format": "date-time",
+                                "description": "ISO 8601 UTC timestamp.",
+                                "type": "string"
+                            },
+                            "updated_at": {
+                                "format": "date-time",
+                                "description": "ISO 8601 UTC timestamp.",
+                                "type": "string"
+                            },
+                            "instance_type": {
+                                "$ref": "#/components/schemas/RegistryInstanceTypeValue",
+                                "description": "Type of the registry instance. This will determine functional and/or non-functional features provided by the registry instance."
+                            }
+                        },
+                        "example": {
+                            "id": "42",
+                            "name": "my-registry",
+                            "registryUrl": "https://registry.apps.example.com/t/5213600b-afc9-487e-8cc3-339f4248d706",
+                            "browserUrl": "https://registry-ui.apps.example.com/t/5213600b-afc9-487e-8cc3-339f4248d706",
+                            "status": {
+                                "status": "PROVISIONING",
+                                "lastUpdated": "2021-05-04T12:34:56Z"
+                            },
+                            "registryDeploymentId": 1,
+                            "owner": "ownername"
+                        }
+                    }
+                ]
+            },
+            "RegistryCreate": {
+                "title": "Root type for RegistryCreate",
+                "description": "Information used to create a new Service Registry instance in a multi-tenant deployment.",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "User-defined `Registry` instance name. Required. Does not have to be unique.",
+                        "maxLength": 32,
+                        "minLength": 1,
+                        "pattern": "[a-z]([a-z0-9\\-]*[a-z0-9])?",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "User-provided description of the new `Registry` instance. Not required.",
+                        "maxLength": 255,
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "name": "my-registry",
+                    "description": "This instance is for development environment only."
+                }
+            },
+            "RegistryList": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/List"
+                    },
+                    {
+                        "required": [
+                            "items"
+                        ],
+                        "type": "object",
+                        "properties": {
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Registry"
+                                }
+                            }
+                        },
+                        "example": {
+                            "kind": "RegistryList",
+                            "page": "1",
+                            "size": "1",
+                            "total": "1",
+                            "item": {
+                                "id": "llmNteR4P7waRp5nJIReG",
+                                "kind": "serviceregistry",
+                                "href": "/api/serviceregistry_mgmt/v1/registries/llmNteR4P7waRp5nJIReG",
+                                "name": "sample-registry",
+                                "status": "ready",
+                                "owner": "some_id",
+                                "registryUrl": "https://somehost:433/t/12345",
+                                "browserUrl": "https://someuihost:443/registries/12345"
+                            }
+                        }
+                    }
+                ]
+            },
+            "RegistryStatusValue": {
+                "description": "\"accepted\": Registry status when accepted for processing.\n\n\"provisioning\": Registry status when provisioning a new instance.\n\n\"ready\": Registry status when ready for use.\n\n\"failed\": Registry status when the provisioning failed. When removing a registry instance in this state,\nthe status transitions directly to \"deleting\".\n\n\n\"deprovision\": Registry status when accepted for deprovisioning.\n\n\"deleting\": Registry status when deprovisioning.\n",
+                "enum": [
+                    "accepted",
+                    "provisioning",
+                    "ready",
+                    "failed",
+                    "deprovision",
+                    "deleting"
+                ],
+                "type": "string"
+            },
+            "RegistryInstanceTypeValue": {
+                "description": "\"standard\": Standard, full-featured registry instance\n\n\"eval\": Evaluation (Trial) instance, provided for a limited time\n",
+                "enum": [
+                    "standard",
+                    "eval"
+                ],
+                "type": "string"
+            },
+            "ServiceStatus": {
+                "title": "Root Type for ServiceStatus",
+                "description": "Schema for the service status response body",
+                "type": "object",
+                "properties": {
+                    "max_instances_reached": {
+                        "description": "Boolean property indicating if the maximum number of total instances have been reached, therefore creation of more instances should not be allowed.",
+                        "type": "boolean"
+                    }
+                },
+                "example": {
+                    "max_instances_reached": true
+                }
             }
-          }
-        ]
-      },
-      "RegistryStatusValue": {
-        "description": "\"accepted\": Registry status when accepted for processing.\n\n\"provisioning\": Registry status when provisioning a new instance.\n\n\"ready\": Registry status when ready for use.\n\n\"failed\": Registry status when the provisioning failed. When removing a Registry in this state,\nthe status transitions directly to \"deleting\".\n\n\n\"deprovision\": Registry status when accepted for deprovisioning.\n\n\"deleting\": Registry status when deprovisioning.\n",
-        "enum": [
-          "accepted",
-          "provisioning",
-          "ready",
-          "failed",
-          "deprovision",
-          "deleting"
-        ],
-        "type": "string"
-      },
-      "RegistryInstanceTypeValue": {
-        "description": "\"standard\": Standard, full-featured Registry instance\n\n\"eval\": Evaluation (Trial) instance, provided for a limited time\n",
-        "enum": [
-          "standard",
-          "eval"
-        ],
-        "type": "string"
-      },
-      "ServiceStatus": {
-        "title": "Root Type for ServiceStatus",
-        "description": "Schema for the service status response body",
-        "type": "object",
-        "properties": {
-          "max_instances_reached": {
-            "description": "Boolean property indicating if the maximum number of total instances have been reached, therefore creation of more instances should not be allowed.",
-            "type": "boolean"
-          }
         },
-        "example": {
-          "max_instances_reached": true
-        }
-      }
-    },
-    "parameters": {
-      "id": {
-        "name": "id",
-        "description": "The id of record",
-        "schema": {
-          "type": "string"
+        "parameters": {
+            "id": {
+                "name": "id",
+                "description": "The id of record",
+                "schema": {
+                    "type": "string"
+                },
+                "in": "path",
+                "required": true
+            },
+            "page": {
+                "examples": {
+                    "page": {
+                        "value": "0"
+                    }
+                },
+                "name": "page",
+                "description": "Page index",
+                "schema": {
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "in": "query",
+                "required": false
+            },
+            "size": {
+                "examples": {
+                    "size": {
+                        "value": "100"
+                    }
+                },
+                "name": "size",
+                "description": "Number of items in each page.",
+                "schema": {
+                    "maximum": 500,
+                    "minimum": 1,
+                    "type": "integer"
+                },
+                "in": "query",
+                "required": false
+            },
+            "orderBy": {
+                "style": "form",
+                "explode": true,
+                "examples": {
+                    "orderBy": {
+                        "value": "name asc"
+                    }
+                },
+                "name": "orderBy",
+                "description": "Specifies the order by criteria. The syntax of this parameter is\nsimilar to the syntax of the _order by_ clause of an SQL statement.\nEach query can be ordered by any of the request fields.\nFor example, to retrieve all registry instances ordered by their name:\n\n```sql\nname asc\n```\n\nOr to retrieve all registry instances ordered by their name _and_ created date:\n\n```sql\nname asc, created_at asc\n```\n\nIf the parameter isn't provided, or if the value is empty, \nthe results will be ordered by name.",
+                "schema": {
+                    "type": "string"
+                },
+                "in": "query",
+                "required": false
+            },
+            "search": {
+                "style": "form",
+                "explode": true,
+                "examples": {
+                    "search": {
+                        "value": "name = my-registry and status = AVAILABLE"
+                    }
+                },
+                "name": "search",
+                "description": "Search criteria.\n\nThe syntax of this parameter is similar to the syntax of the _where_ clause of an\nSQL statement. Allowed fields in the search are: `name`, `status`. Allowed comparators are `=` or `LIKE`.\nAllowed joins are `AND` and `OR`, however there is a limit of max 10 joins in the search query.\n\nExamples:\n\nTo retrieve request with name equal `my-registry`  the value should be:\n\n```\nname = my-registry \n```\n\nTo retrieve a registry request with its name starting with `my`, the value should be:\n\n```\nname like my%25\n```\n\nIf the parameter isn't provided, or if the value is empty, all the registry instances\nthat the user has permission to see will be returned.\n\nNote: If the query is invalid, an error will be returned.\n",
+                "schema": {
+                    "type": "string"
+                },
+                "in": "query",
+                "required": false
+            }
         },
-        "in": "path",
-        "required": true
-      },
-      "page": {
         "examples": {
-          "page": {
-            "value": "0"
-          }
+            "404Example": {
+                "value": {
+                    "id": "404",
+                    "kind": "Error",
+                    "href": "/api/managed-services-api/v1/errors/7",
+                    "code": "MGD-SERV-API-7",
+                    "reason": "The requested resource doesn't exist"
+                }
+            },
+            "401Example": {
+                "value": {
+                    "id": "11",
+                    "kind": "Error",
+                    "href": "/api/serviceregistry_mgmt/v1/errors/11",
+                    "code": "CLOUD-SERV-API-11",
+                    "reason": "Unable to verify JWT token: Required authorization token not found",
+                    "operation_id": "1iY3UhEhwmXBpWPfI2lNekpd4ZD"
+                }
+            },
+            "403Example": {
+                "value": {
+                    "id": "4",
+                    "kind": "Error",
+                    "href": "/api/serviceregistry_mgmt/v1/errors/4",
+                    "code": "MGD-SERV-API-4",
+                    "reason": "User 'foo-bar' is not authorized to access the service.",
+                    "operation_id": "1lY3UiEhznXBpWPfI2lNejpd4YC"
+                }
+            },
+            "500Example": {
+                "value": {
+                    "id": "9",
+                    "kind": "Error",
+                    "href": "/api/serviceregistry_mgmt/v1/errors/9",
+                    "code": "MGD-SERV-API-9",
+                    "reason": "Unspecified error",
+                    "operation_id": "1ieELvF9jMQY6YghfM9gGRsHvEW"
+                }
+            }
         },
-        "name": "page",
-        "description": "Page index",
-        "schema": {
-          "minimum": 0,
-          "type": "integer"
-        },
-        "in": "query",
-        "required": false
-      },
-      "size": {
-        "examples": {
-          "size": {
-            "value": "100"
-          }
-        },
-        "name": "size",
-        "description": "Number of items in each page",
-        "schema": {
-          "maximum": 500,
-          "minimum": 1,
-          "type": "integer"
-        },
-        "in": "query",
-        "required": false
-      },
-      "orderBy": {
-        "style": "form",
-        "explode": true,
-        "examples": {
-          "orderBy": {
-            "value": "name asc"
-          }
-        },
-        "name": "orderBy",
-        "description": "Specifies the order by criteria. The syntax of this parameter is\nsimilar to the syntax of the _order by_ clause of an SQL statement.\nEach query can be ordered by any of the kafkaRequests fields.\nFor example, in order to retrieve all kafkas ordered by their name:\n\n```sql\nname asc\n```\n\nOr in order to retrieve all kafkas ordered by their name _and_ created date:\n\n```sql\nname asc, created_at asc\n```\n\nIf the parameter isn't provided, or if the value is empty, then\nthe results will be ordered by name.",
-        "schema": {
-          "type": "string"
-        },
-        "in": "query",
-        "required": false
-      },
-      "search": {
-        "style": "form",
-        "explode": true,
-        "examples": {
-          "search": {
-            "value": "name = my-registry and status = AVAILABLE"
-          }
-        },
-        "name": "search",
-        "description": "Search criteria.\n\nThe syntax of this parameter is similar to the syntax of the _where_ clause of an\nSQL statement. Allowed fields in the search are: name, status. Allowed comparators are `=` or `LIKE`.\nAllowed joins are `AND` and `OR`, however there is a limit of max 10 joins in the search query.\n\nExamples:\n\nTo retrieve request with name equal `my-registry`  the value should be:\n\n```\nname = my-registry \n```\n\nTo retrieve kafka request with its name starting with `my`, the value should be:\n\n```\nname like my%25\n```\n\nIf the parameter isn't provided, or if the value is empty, then all the kafkas\nthat the user has permission to see will be returned.\n\nNote. If the query is invalid, an error will be returned\n",
-        "schema": {
-          "type": "string"
-        },
-        "in": "query",
-        "required": false
-      }
-    },
-    "examples": {
-      "404Example": {
-        "value": {
-          "id": "404",
-          "kind": "Error",
-          "href": "/api/managed-services-api/v1/errors/7",
-          "code": "MGD-SERV-API-7",
-          "reason": "The requested resource doesn't exist"
+        "securitySchemes": {
+            "Bearer": {
+                "scheme": "bearer",
+                "bearerFormat": "JWT",
+                "type": "http"
+            }
         }
-      },
-      "401Example": {
-        "value": {
-          "id": "11",
-          "kind": "Error",
-          "href": "/api/serviceregistry_mgmt/v1/errors/11",
-          "code": "CLOUD-SERV-API-11",
-          "reason": "Unable to verify JWT token: Required authorization token not found",
-          "operation_id": "1iY3UhEhwmXBpWPfI2lNekpd4ZD"
-        }
-      },
-      "403Example": {
-        "value": {
-          "id": "4",
-          "kind": "Error",
-          "href": "/api/serviceregistry_mgmt/v1/errors/4",
-          "code": "MGD-SERV-API-4",
-          "reason": "User 'foo-bar' is not authorized to access the service.",
-          "operation_id": "1lY3UiEhznXBpWPfI2lNejpd4YC"
-        }
-      },
-      "500Example": {
-        "value": {
-          "id": "9",
-          "kind": "Error",
-          "href": "/api/serviceregistry_mgmt/v1/errors/9",
-          "code": "MGD-SERV-API-9",
-          "reason": "Unspecified error",
-          "operation_id": "1ieELvF9jMQY6YghfM9gGRsHvEW"
-        }
-      }
-    },
-    "securitySchemes": {
-      "Bearer": {
-        "scheme": "bearer",
-        "bearerFormat": "JWT",
-        "type": "http"
-      }
     }
-  }
 }


### PR DESCRIPTION
Cleans up the REST API doc and fixes a few typos (e.g., references to Kafka instances instead of Registry instances). 

@EricWittmann @jsenko Can you take a look? I followed the process in https://github.com/bf2fc6cc711aee1a0c2a/srs-fleet-manager/blob/main/CONTRIBUTING.md, but there seems to be a couple of import diffs in the generated code? Apicurio Studio has also reformatted the JSON file. 

I don't want to break anything important here! :) 