### PR TITLE
fix: add codeowners for api changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+core/src/main/resources/srs-fleet-manager.json @bf2fc6cc711aee1a0c2a/devexp-sdks


### PR DESCRIPTION
For SDKs we need to be able to view changes in the SDK before they are merged to review and prepare for them to land.