### PR TITLE
Use Temurin Distribution

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -19,11 +19,11 @@ jobs:
     if: github.repository_owner == 'bf2fc6cc711aee1a0c2a'
     steps:
 
-      - name: Install JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          version: 11
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Checkout "${{ github.ref }}"
         uses: actions/checkout@v2

--- a/.github/workflows/update-apicurio-deps.yaml
+++ b/.github/workflows/update-apicurio-deps.yaml
@@ -10,11 +10,11 @@ jobs:
     if: github.repository_owner == 'bf2fc6cc711aee1a0c2a'
     steps:
 
-      - name: Install JDK 11
-        uses: AdoptOpenJDK/install-jdk@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
         with:
-          version: 11
-          architecture: x64
+          java-version: '11'
+          distribution: 'temurin'
 
       - name: Checkout "${{ github.ref }}"
         uses: actions/checkout@v2


### PR DESCRIPTION
Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates.