### PR TITLE
ci: bumps the versions of RHOAS Guidelines and spectral linter

### DIFF
--- a/.github/workflows/openapi_lint.yaml
+++ b/.github/workflows/openapi_lint.yaml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - core/src/main/resources/srs-fleet-manager.json
+    # paths:
+    #   - core/src/main/resources/srs-fleet-manager.json
 
 jobs:
   validate:

--- a/.github/workflows/openapi_lint.yaml
+++ b/.github/workflows/openapi_lint.yaml
@@ -19,8 +19,5 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
-      - run: yarn add @stoplight/spectral@5.9.0
-      # getting the ruleset from the RHOAS repo
-      - run: yarn add @rhoas/spectral-ruleset
-      - run: yarn install
-      - run: yarn spectral lint ./core/src/main/resources/srs-fleet-manager.json
+      - run: npm i @rhoas/spectral-ruleset@0.3.0-dev6
+      - run: npx rhoasapi lint ./core/src/main/resources/srs-fleet-manager.json

--- a/.github/workflows/openapi_lint.yaml
+++ b/.github/workflows/openapi_lint.yaml
@@ -4,8 +4,8 @@ on:
   pull_request:
     branches:
       - main
-    # paths:
-    #   - core/src/main/resources/srs-fleet-manager.json
+    paths:
+      - core/src/main/resources/srs-fleet-manager.json
 
 jobs:
   validate:


### PR DESCRIPTION
Verification:

I briefly disabled the check for paths on the openapi lint gh action to run the action as can be seen [here:](https://github.com/bf2fc6cc711aee1a0c2a/srs-fleet-manager/runs/7676458300?check_suite_focus=true) the run was successful.

I've added the path conditional back in

ps. the reason I needed to disable the check for paths is because the action otherwise won't run if the oas file isn't edited