### PR TITLE
chore: now push openapi chages to sdk core

### DIFF
--- a/.github/workflows/openapi_update.yaml
+++ b/.github/workflows/openapi_update.yaml
@@ -15,7 +15,7 @@ jobs:
       APP_SERVICES_CI_TOKEN: ${{ secrets.APP_SERVICES_CI_TOKEN }}
     strategy:
       matrix:
-        repo: [ "redhat-developer/app-services-sdk-go", "redhat-developer/app-services-sdk-js", "redhat-developer/app-services-sdk-java" ]
+        repo: [ "redhat-developer/app-services-sdk-go", "redhat-developer/app-services-sdk-js", "redhat-developer/app-services-sdk-java", "redhat-developer/app-services-sdk-core" ]
     runs-on: ubuntu-latest
     if: github.repository_owner == 'bf2fc6cc711aee1a0c2a'
     steps:


### PR DESCRIPTION
## Description
This pr enables changes to the openapi spec to be push to the core SDK repo aswell as the other SDKs.

## Jjra
https://issues.redhat.com/browse/MGDX-284