### PR TITLE
Avoid overriding properties in OpenAPI Spec

### DIFF
--- a/core/src/main/resources/srs-fleet-manager.json
+++ b/core/src/main/resources/srs-fleet-manager.json
@@ -497,31 +497,12 @@
   },
   "components": {
     "schemas": {
-      "ErrorList": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/List"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "items": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          }
-        ]
-      },
-      "List": {
+      "AbstractList": {
         "required": [
           "kind",
           "page",
           "size",
-          "total",
-          "items"
+          "total"
         ],
         "type": "object",
         "properties": {
@@ -536,14 +517,50 @@
           },
           "total": {
             "type": "integer"
-          },
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ObjectReference"
-            }
           }
         }
+      },
+      "ErrorList": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AbstractList"
+          },
+          {
+            "required": [
+              "items"
+            ],
+            "type": "object",
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "List": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AbstractList"
+          },
+          {
+            "required": [
+              "items"
+            ],
+            "type": "object",
+            "properties": {
+              "items": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ObjectReference"
+                }
+              }
+            }
+          }
+        ]
       },
       "Error": {
         "required": [
@@ -578,7 +595,7 @@
       "RegistryList": {
         "allOf": [
           {
-            "$ref": "#/components/schemas/List"
+            "$ref": "#/components/schemas/AbstractList"
           },
           {
             "required": [


### PR DESCRIPTION
According to this open issue: https://github.com/OAI/OpenAPI-Specification/issues/3069

Overriding properties seems to be an undefined behavior, I found this edge case used here and I'm proposing a possible fix.
Refactoring the common properties of `List` into `AbstractList` and explicitly defining `items` instead of overriding it.

(BTW, found generating a client using Kiota.)